### PR TITLE
Value for keyPath instead of change dict

### DIFF
--- a/BIND/Classes/BNDBinding.m
+++ b/BIND/Classes/BNDBinding.m
@@ -329,7 +329,7 @@ NSString * const BNDBindingAssociatedBindingsKey = @"BNDBindingAssociatedBinding
     
     [self lockObservation];
     
-    id newObject = change[NSKeyValueChangeNewKey];
+    id newObject = [object valueForKeyPath:keyPath];
     if ([newObject isKindOfClass:[NSNull class]]) {
         newObject = nil;
     }


### PR DESCRIPTION
Now returning value for keyPath when observing instead of new value from change dictionary