### PR TITLE
Fix reference counting

### DIFF
--- a/BIND/Classes/BNDBinding.m
+++ b/BIND/Classes/BNDBinding.m
@@ -22,7 +22,7 @@ NSString * const BNDBindingAssociatedBindingsKey = @"BNDBindingAssociatedBinding
 
 @interface BNDBindingKVOObserver : NSObject
 @property (nonatomic, copy, readonly) NSString *keyPath;
-@property (nonatomic, weak, readonly) BNDBinding *binding;
+@property (nonatomic, strong, readonly) BNDBinding *binding;
 
 + (instancetype)observerWithKeyPath:(NSString *)keyPath
                             binding:(BNDBinding *)binding;
@@ -41,8 +41,8 @@ NSString * const BNDBindingAssociatedBindingsKey = @"BNDBindingAssociatedBinding
 @property (nonatomic, strong) NSValueTransformer *valueTransformer;
 @property (nonatomic) BOOL shouldSetInitialValues;
 
-@property (nonatomic, strong) BNDBindingKVOObserver *leftObserver;
-@property (nonatomic, strong) BNDBindingKVOObserver *rightObserver;
+@property (nonatomic, weak) BNDBindingKVOObserver *leftObserver;
+@property (nonatomic, weak) BNDBindingKVOObserver *rightObserver;
 
 @property (nonatomic) SEL transformSelector;
 @property (nonatomic) SEL reverseTransformSelector;


### PR DESCRIPTION
I don't know how this could possibly work, but if you create a new application, add this lib and just try to BINDO with -observe: it won't work, because right after the creation of the binding it gets deallocated: `BNDBinding` is not retained. You had an `NSMutableSet`, where you add `BNDBinding`s, but now it's gone and only `BNDBindingKVOObserver` are retained by association. But they have a weak reference to parent `BNDBinding`. That's a fail.

To fix this we must make `BNDBindingKVOObserver`s to hold strong reference to parent `BNDBinding`.